### PR TITLE
Add Safari-friendly sample habit tracker

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,84 @@
+(function () {
+  var form = document.querySelector('.task-form');
+  var input = document.getElementById('task-input');
+  var list = document.getElementById('task-list');
+  var count = document.getElementById('task-count');
+
+  var tasks = [];
+
+  function updateCount() {
+    count.textContent = String(tasks.length);
+  }
+
+  function createTaskElement(task) {
+    var item = document.createElement('li');
+    item.className = 'task-item';
+
+    var label = document.createElement('label');
+    label.className = 'task-item__label';
+
+    var checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'task-item__checkbox';
+    checkbox.checked = task.done;
+
+    var text = document.createElement('span');
+    text.className = 'task-item__text';
+    text.textContent = task.label;
+
+    var remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'task-item__remove';
+    remove.textContent = '削除';
+
+    label.appendChild(checkbox);
+    label.appendChild(text);
+    item.appendChild(label);
+    item.appendChild(remove);
+
+    if (task.done) {
+      item.className += ' task-item--done';
+    }
+
+    checkbox.addEventListener('change', function () {
+      task.done = checkbox.checked;
+      if (task.done) {
+        if (item.className.indexOf('task-item--done') === -1) {
+          item.className += ' task-item--done';
+        }
+      } else {
+        item.className = item.className.replace(' task-item--done', '');
+      }
+    });
+
+    remove.addEventListener('click', function () {
+      list.removeChild(item);
+      tasks = tasks.filter(function (current) {
+        return current !== task;
+      });
+      updateCount();
+    });
+
+    return item;
+  }
+
+  form.addEventListener('submit', function (event) {
+    event.preventDefault();
+    var value = input.value.trim();
+    if (!value) {
+      return;
+    }
+
+    var task = {
+      label: value,
+      done: false
+    };
+
+    tasks.push(task);
+    list.appendChild(createTaskElement(task));
+    input.value = '';
+    updateCount();
+  });
+
+  updateCount();
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Safari対応サンプルアプリ</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <p class="app__eyebrow">Safari対応サンプル</p>
+        <h1>シンプル習慣トラッカー</h1>
+        <p class="app__lead">今日やりたいことを登録して、達成したらチェックしましょう。</p>
+      </header>
+
+      <section class="app__panel">
+        <form class="task-form" aria-label="やること追加フォーム">
+          <label class="task-form__label" for="task-input">やること</label>
+          <div class="task-form__controls">
+            <input
+              id="task-input"
+              name="task"
+              type="text"
+              placeholder="例: 散歩に行く"
+              autocomplete="off"
+              required
+            />
+            <button type="submit">追加</button>
+          </div>
+        </form>
+
+        <div class="task-summary" aria-live="polite">
+          <span id="task-count">0</span> 件のタスク
+        </div>
+
+        <ul class="task-list" id="task-list" aria-label="タスクリスト"></ul>
+      </section>
+
+      <section class="app__panel tips">
+        <h2>ヒント</h2>
+        <ul>
+          <li>クリックで完了にできます。</li>
+          <li>右側の削除ボタンで取り消せます。</li>
+          <li>Safariでも動くように、最新仕様のAPIは使っていません。</li>
+        </ul>
+      </section>
+    </main>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,173 @@
+:root {
+  color-scheme: light;
+  font-family: "Hiragino Sans", "Noto Sans JP", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  background: #f5f4f8;
+  color: #1f2430;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 32px 20px 56px;
+  min-height: 100vh;
+}
+
+.app {
+  max-width: 920px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.app__header {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 28px 32px;
+  box-shadow: 0 12px 30px rgba(31, 36, 48, 0.08);
+}
+
+.app__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  color: #56607a;
+  margin: 0 0 8px;
+}
+
+h1 {
+  font-size: 28px;
+  margin: 0 0 8px;
+}
+
+.app__lead {
+  margin: 0;
+  color: #445069;
+}
+
+.app__panel {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 24px 28px;
+  box-shadow: 0 10px 20px rgba(31, 36, 48, 0.07);
+}
+
+.task-form {
+  display: grid;
+  gap: 12px;
+}
+
+.task-form__label {
+  font-weight: 600;
+  color: #3a435a;
+}
+
+.task-form__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.task-form input {
+  flex: 1 1 220px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid #d6d9e0;
+  font-size: 16px;
+}
+
+.task-form button {
+  padding: 12px 18px;
+  border-radius: 10px;
+  border: none;
+  background: #2f5ce3;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.task-form button:hover {
+  background: #2549b8;
+}
+
+.task-summary {
+  margin: 18px 0 0;
+  font-weight: 600;
+  color: #2f3a4f;
+}
+
+.task-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #f7f8fb;
+  border: 1px solid #e2e6ef;
+}
+
+.task-item__label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+}
+
+.task-item__checkbox {
+  width: 18px;
+  height: 18px;
+}
+
+.task-item--done {
+  background: #e8f3ea;
+  border-color: #c9e2cf;
+  color: #2f6242;
+}
+
+.task-item--done .task-item__text {
+  text-decoration: line-through;
+}
+
+.task-item__remove {
+  border: none;
+  background: transparent;
+  color: #8a94a6;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.task-item__remove:hover {
+  color: #d04f4f;
+}
+
+.tips ul {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: #445069;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 20px 16px 40px;
+  }
+
+  .app__header,
+  .app__panel {
+    padding: 20px;
+  }
+
+  h1 {
+    font-size: 24px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, Safari-compatible sample application for demonstrating a lightweight habit tracker UI.  
- Keep implementation compatible with older WebKit/Safari by avoiding newer platform APIs.  
- Offer a minimal, responsive static site that shows task creation, completion, and removal behavior.  

### Description
- Add static assets: `index.html`, `styles.css`, and `app.js` implementing the UI and behavior.  
- Implement task creation via a form, task completion toggling with a checkbox, task removal via a button, and a live task count.  
- Include basic accessibility attributes such as `aria-label` and `aria-live` for the task list and summary.  
- Provide responsive CSS to support mobile Safari and desktop layouts without relying on newest browser APIs.  

### Testing
- Started a local server with `python -m http.server 8000` and served the site successfully.  
- Ran a Playwright script that visited `http://127.0.0.1:8000/index.html` and saved a screenshot to `artifacts/safari-sample-app.png`, which completed successfully.  
- No automated unit tests were added or run for this static site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c113fad8c8323a8b55f27101e3c94)